### PR TITLE
Test against more Djangos and Pythons.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,12 @@
 
 language: python
 
+dist: trusty
+
+sudo: true
+
 python:
+  - "3.6"
   - "3.5"
   - "3.4"
   - "2.7"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,3 @@
-django>=1.9.6
 pytest-cov
 pytest-django
 pytest-logger

--- a/setup.py
+++ b/setup.py
@@ -61,5 +61,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,9 @@
 from django.test import LiveServerTestCase
-from django.urls import reverse
+
+try:
+    from django.urls import reverse
+except ImportError:  # django < 1.10
+    from django.core.urlresolvers import reverse
 
 from tusclient import client
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,22 +1,20 @@
-from django.test import LiveServerTestCase
-
 try:
     from django.urls import reverse
 except ImportError:  # django < 1.10
     from django.core.urlresolvers import reverse
 
-from tusclient import client
+from tusclient.client import TusClient
 
 
-class TestUploadView(LiveServerTestCase):
+class TestUploadView(object):
 
-    def test_get_is_not_allowed(self):
-        response = self.client.get(reverse('tus_upload'))
+    def test_get_is_not_allowed(self, client):
+        response = client.get(reverse('tus_upload'))
         assert response.status_code == 405
 
-    def test_upload_file(self):
-        tus_client = client.TusClient(
-            self.live_server_url + reverse('tus_upload')
+    def test_upload_file(self, live_server):
+        tus_client = TusClient(
+            live_server.url + reverse('tus_upload')
         )
         uploader = tus_client.uploader('tests/files/hello_world.txt', chunk_size=200)
         uploader.upload()

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ envlist =
 
 [testenv]
 deps =
-    django-19: Django>=1.9,<1.10
-    django-110: Django>=1.10
+    django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
     -r{toxinidir}/requirements_test.txt
     # Prevent "test command found but not installed in testenv"
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,13 @@
 envlist =
     {py27,py34,py35}-django19
     {py27,py34,py35}-django110
+    {py27,py34,py35,py36}-django111
 
 [testenv]
 deps =
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<1.12
     -r{toxinidir}/requirements_test.txt
     # Prevent "test command found but not installed in testenv"
     pytest


### PR DESCRIPTION
Let's prove that we support Python 3.6 and more recent releases of Django 1.11.