### PR TITLE
remove providing_args from signal

### DIFF
--- a/django_tus/signals.py
+++ b/django_tus/signals.py
@@ -1,13 +1,13 @@
 import django.dispatch
 
 
-tus_upload_finished_signal = django.dispatch.Signal(
-    providing_args=[
-        "metadata",
-        "filename",
-        "upload_file_path",
-        "file_size",
-        "upload_url",
-        "destination_folder"
-    ]
-)
+tus_upload_finished_signal = django.dispatch.Signal()
+"""
+This signal provides the following keyword arguments:
+    metadata
+    filename
+    upload_file_path
+    file_size
+    upload_url
+    destination_folder
+"""


### PR DESCRIPTION
The argument `providing_args` was deprecated in Django 3.1 as it was purely documentational (https://docs.djangoproject.com/en/4.1/releases/3.1/#id2). Removing this allows us to use newer versions of Django (e.g. 4.1) with `django-tus`